### PR TITLE
fix include

### DIFF
--- a/Acquisition/SendData__Version_1_0_0/include/bitwise_operations.h
+++ b/Acquisition/SendData__Version_1_0_0/include/bitwise_operations.h
@@ -10,8 +10,8 @@
  * 
  */
 
-#include "stdio.h"
-#include "stdint.h"
+#include <stdio.h>
+#include <stdint.h>
 
 /* Mask functions */
 uint8_t  mask_8_bit(uint8_t n1, uint8_t mask);

--- a/Acquisition/SendData__Version_1_0_0/include/sendData.h
+++ b/Acquisition/SendData__Version_1_0_0/include/sendData.h
@@ -10,8 +10,8 @@
  * 
  */
 
-#include "Arduino.h"
-#include "Encoder.h"
+#include <Arduino.h>
+#include <Encoder.h>
 
 unsigned long CURRENT_MICROS;
 uint32_t WAIT_TIME_MICROS = 500;


### PR DESCRIPTION
" include " --> l'ordinateur va chercher la bibliothèque d'abord dans nos fichiers avant de chercher dans ses bibliothèques 
< include > --> l'ordinateur va chercher directement dans ses bibliothèques sans passer par nos fichiers ce qui nous fait gagner du temps d'exécution du programme. 
On a donc transformé certains include dont la bibliothèque utilisée ne nous appartenait pas.
